### PR TITLE
Bundle js and css inside index.html

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "globals": "^15.14.0",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.18.2",
-    "vite": "^6.0.5"
+    "vite": "^6.0.5",
+    "vite-plugin-singlefile": "^2.1.0"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,14 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import tailwindcss from '@tailwindcss/vite'
+import {viteSingleFile} from "vite-plugin-singlefile";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(),tailwindcss()],
+  plugins: [react(),tailwindcss(), viteSingleFile()],
   base: "./",
   build: {
     assetsDir: "src",
-    minify: false,
+    minify: false
   },
 });


### PR DESCRIPTION
Sadly Vite does not support not using `type="module"` in the built index.html anymore.
However `type="module"` is forbidden when using the `file://` protocol that Nanos uses.

The most popular way of bundling with Vite offline embedded applications is bundling everything js and css wise in the index.html  using the vite-singlefile package.

This may or may not suit your needs, but it works great for your UI :)

![image](https://github.com/user-attachments/assets/f0b38f50-ac97-4a7f-99ac-a3e7061f4d8b)

Have fun !

